### PR TITLE
Improving compatibility for building the `conio/adventure` example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ utils/dcbumpgen/dcbumpgen
 examples/dreamcast/basic/exec/romdisk/sub.bin
 examples/dreamcast/kgl/basic/vq/fruit.vq
 examples/dreamcast/conio/adventure/data.c
+examples/dreamcast/conio/adventure/datagen
 examples/dreamcast/conio/adventure/setup
 examples/dreamcast/png/romdisk_boot.img
 examples/dreamcast/pvr/modifier_volume_tex/romdisk/fruit.kmg

--- a/examples/dreamcast/conio/adventure/Makefile
+++ b/examples/dreamcast/conio/adventure/Makefile
@@ -4,28 +4,56 @@
 # (c)2002 Dan Potter
 #
 
-all: rm-elf adventure.elf
+include Makefile.hostdetect
+
+# Program binary
+TARGET = adventure.elf
+
+# Script data files
+DATA_SOURCE = glorkz
+DATA_TARGET = data.c
+
+# For MinGW/MSYS, MinGW-w64/MSYS2 and Cygwin
+ifdef WINDOWS
+  EXECUTABLEEXTENSION = .exe
+endif
+
+# Setup data utility processing
+# Under Windows, avoid the "setup.exe" name as it causes problems with the UAC...
+SETUP_SOURCE = setup.c
+SETUP_TARGET = datagen$(EXECUTABLEEXTENSION)
+SETUP_CFLAGS = -DSETUP
+
+# Only for MinGW-w64/MSYS2, even if x86!
+ifdef MINGW64
+  SETUP_CFLAGS += -D_MINGW_W64
+endif
+
+# Additional configuration
+HOST_CC = gcc
+
+all: rm-elf $(TARGET)
 
 include $(KOS_BASE)/Makefile.rules
 
 OBJS = porthelper.o crc.o done.o init.o io.o main.o save.o subr.o vocab.o wizard.o data.o
 
-data.c:
-	gcc -o setup setup.c -DSETUP
-	./setup glorkz > data.c
+$(DATA_TARGET):
+	$(HOST_CC) -o $(SETUP_TARGET) $(SETUP_SOURCE) $(SETUP_CFLAGS)
+	./$(SETUP_TARGET) $(DATA_SOURCE) > $(DATA_TARGET)
 
 clean:
-	-rm -f adventure.elf $(OBJS) data.c setup
+	-rm -f $(TARGET) $(OBJS) $(DATA_TARGET) $(SETUP_TARGET)
 
 rm-elf:
-	-rm -f adventure.elf
+	-rm -f $(TARGET)
 
-adventure.elf: $(OBJS) 
-	$(KOS_CC) $(KOS_CFLAGS) $(KOS_LDFLAGS) -o adventure.elf $(KOS_START) $(OBJS) $(DATAOBJS) $(OBJEXTRA) -lconio $(KOS_LIBS)
+$(TARGET): $(OBJS) 
+	$(KOS_CC) $(KOS_CFLAGS) $(KOS_LDFLAGS) -o $(TARGET) $(KOS_START) $(OBJS) $(DATAOBJS) $(OBJEXTRA) -lconio $(KOS_LIBS)
 
-run: adventure.elf
-	$(KOS_LOADER) adventure.elf
+run: $(TARGET)
+	$(KOS_LOADER) $(TARGET)
 
 dist:
-	-rm -f $(OBJS) data.c setup
-	$(KOS_STRIP) adventure.elf
+	-rm -f $(OBJS) $(DATA_TARGET) $(SETUP_TARGET)
+	$(KOS_STRIP) $(TARGET)

--- a/examples/dreamcast/conio/adventure/Makefile.hostdetect
+++ b/examples/dreamcast/conio/adventure/Makefile.hostdetect
@@ -1,0 +1,40 @@
+# Determine on what platform we are running
+
+# This is much more simpler than using the "config.guess" mechanism, as we 
+# don't need the full host triplet, but it will be sufficient here.
+
+# For a more complete mechanism, based on host triplet and "config.guess", 
+# check the "dc-chain/Makefile".
+
+HOST = $(shell uname -s)
+
+# BSD
+ifneq ($(shell echo $(HOST) | grep -i 'BSD$$'),)
+  BSD := 1
+endif
+
+# macOS
+ifeq ($(shell echo $(HOST)),Darwin)
+  MACOS := 1
+endif
+
+# MinGW/MSYS
+ifeq ($(shell echo $(HOST) | cut -c-5),MINGW)
+# Both MinGW/MSYS legacy environment and MinGW-w64/MSYS2 environment
+  MINGW32 := 1
+  mingw_w64_checker = $(shell echo $$MSYSTEM_CHOST)
+  ifneq ($(mingw_w64_checker),)
+# Only MinGW-w64/MSYS2 environment, both for x86 / x64
+    MINGW64 := 1
+  else
+# Only original and legacy MinGW/MSYS environment
+    MINGW := 1
+  endif
+  WINDOWS := 1
+endif
+
+# Cygwin
+ifeq ($(shell echo $(HOST) | cut -c-6),CYGWIN)
+  CYGWIN := 1
+  WINDOWS := 1
+endif

--- a/examples/dreamcast/conio/adventure/hdr.h
+++ b/examples/dreamcast/conio/adventure/hdr.h
@@ -55,6 +55,20 @@
 
 /* hdr.h: included by c advent files */
 #ifdef SETUP
+
+#ifdef __MINGW32__
+#ifdef _MINGW_W64
+/* MinGW-w64/MSYS2 */
+typedef unsigned long u_long;
+#else
+/* MinGW/MSYS */
+#define _BSD_SOURCE
+#include <sys/bsdtypes.h>
+#endif
+#include <stdlib.h>
+#define srandom srand
+#endif /* __MINGW32__ */
+
 #include <sys/types.h>
 #include <signal.h>
 #else

--- a/examples/dreamcast/conio/adventure/setup.c
+++ b/examples/dreamcast/conio/adventure/setup.c
@@ -66,7 +66,7 @@ static const char rcsid[] =
 /* #include <err.h> */
 #include "hdr.h"        /* SEED lives in there; keep them coordinated. */
 
-#define USAGE "Usage: setup file > data.c (file is typically glorkz)"
+#define USAGE "Usage: setup file > data.c (file is typically glorkz)\n"
 
 #define YES 1
 #define NO  0
@@ -78,10 +78,15 @@ main(int argc, char **argv) {
     FILE *infile;
     int c, count, linestart;
 
-    if(argc != 2) printf(USAGE);
+    if(argc != 2) {
+		printf(USAGE);
+		exit(2);
+	}
 
-    if((infile = fopen(argv[1], "r")) == NULL)
-        printf("Can't read file %s", argv[1]);
+    if((infile = fopen(argv[1], "r")) == NULL) {
+        printf("Can't read file %s\n", argv[1]);
+		exit(1);
+	}
 
     puts("/*\n * data.c: created by setup from the ascii data file.");
     puts(SIG1);


### PR DESCRIPTION
The issue was caused by the host application `setup` built at the same time of the `adventure.elf` binary file.
The `setup` binary was renamed to `datagen`, since on **Microsoft Windows**, the `setup.exe` name causes issues with the User Account Control (UAC).
The program compiles now fine under the **MinGW/MSYS** and **MinGW-w64/MSYS2** environments.