### PR TITLE
Copy GNU configs into toolchain sources

### DIFF
--- a/utils/dc-chain/.gitignore
+++ b/utils/dc-chain/.gitignore
@@ -8,4 +8,5 @@ insight-*
 build-*
 *.stamp
 config.guess
+config.sub
 config.mk

--- a/utils/dc-chain/scripts/clean.mk
+++ b/utils/dc-chain/scripts/clean.mk
@@ -50,6 +50,8 @@ clean-gdb-archives:
 	-rm $(gdb_file)
 
 clean-arm-archives:
+	-rm $(config_guess)
+	-rm $(config_sub)
 	-rm $(arm_binutils_file)
 	-rm $(arm_gcc_file)
 	-rm $(arm_gmp_file)
@@ -58,6 +60,8 @@ clean-arm-archives:
 	-rm $(arm_isl_file)
 
 clean-sh-archives:
+	-rm $(config_guess)
+	-rm $(config_sub)
 	-rm $(sh_binutils_file)
 	-rm $(sh_gcc_file)
 	-rm $(newlib_file)

--- a/utils/dc-chain/scripts/host-detect.mk
+++ b/utils/dc-chain/scripts/host-detect.mk
@@ -13,6 +13,8 @@
 # This will help a lot to execute conditional steps depending on the host.
 config_guess = config.guess
 config_guess_url = http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=${config_guess};hb=HEAD
+config_sub = config.sub
+config_sub_url = http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=${config_sub};hb=HEAD
 
 is_clean_target=$(findstring clean,$(MAKECMDGOALS))
 config_guess_check=$(shell test -f ./config.guess || echo 0)
@@ -20,6 +22,7 @@ ifeq ($(is_clean_target),)
   ifeq ($(config_guess_check),0)
     $(info Downloading $(config_guess))
     $(shell $(call web_download,$(config_guess_url),$(config_guess)))
+    $(shell $(call web_download,$(config_sub_url),$(config_sub)))
     $(shell chmod +x $(config_guess))
   endif
 endif

--- a/utils/dc-chain/scripts/patch.mk
+++ b/utils/dc-chain/scripts/patch.mk
@@ -87,6 +87,25 @@ define patch_apply
 	fi;
 endef
 
+# This function is used to replace the config.guess & config.sub that come 
+# bundled with the sources with updated versions from GNU. This fixes issues
+# when trying to compile older versions of the toolchain software on newer
+# hardware.
+define update_configs
+	@echo "+++ Updating $(1) files in $(src_dir)"; \
+	files=$$(find $(src_dir) -name $(1)); \
+	echo "$${files}" | while I= read -r line; do \
+		echo "    $${line}"; \
+		cp $(1) $${line} > /dev/null; \
+	done; \
+	echo ""
+endef
+
+define update_config_guess_sub
+	$(call update_configs,config.guess)
+	$(call update_configs,config.sub)
+endef
+
 # Binutils
 $(patch_binutils): patch_target_name = Binutils
 $(patch_binutils): src_dir = binutils-$(binutils_ver)
@@ -95,6 +114,7 @@ $(patch_binutils): diff_patches := $(wildcard $(patches)/$(src_dir)*.diff)
 $(patch_binutils): diff_patches += $(wildcard $(patches)/$(host_triplet)/$(src_dir)*.diff)
 $(patch_binutils):
 	$(call patch_apply)
+	$(call update_config_guess_sub)
 
 # GNU Compiler Collection (GCC)
 $(patch_gcc): patch_target_name = GCC
@@ -109,6 +129,7 @@ endif
 endif
 $(patch_gcc):
 	$(call patch_apply)
+	$(call update_config_guess_sub)
 
 # Newlib
 $(patch_newlib): patch_target_name = Newlib
@@ -118,6 +139,7 @@ $(patch_newlib): diff_patches := $(wildcard $(patches)/$(src_dir)*.diff)
 $(patch_newlib): diff_patches += $(wildcard $(patches)/$(host_triplet)/$(src_dir)*.diff)
 $(patch_newlib):
 	$(call patch_apply)
+	$(call update_config_guess_sub)
 
 # KallistiOS
 $(patch_kos): patch_target_name = KallistiOS


### PR DESCRIPTION
This change downloads the newest versions of config.guess & config.sub into the dc-chain directory and then uses those files to replace any found in the downloaded sources. This should fix issues when building older releases on newer machines that the old scripts wouldn't recognize properly.